### PR TITLE
general enhancements

### DIFF
--- a/os/board/image-matrix.groovy
+++ b/os/board/image-matrix.groovy
@@ -21,7 +21,7 @@ properties([
     ])
 ])
 
-node('coreos && sudo') {
+node('coreos && amd64 && sudo') {
     ws("${env.WORKSPACE}/${params.BOARD}") {
         stage('Build') {
             step([$class: 'CopyArtifact',

--- a/os/board/packages-matrix.groovy
+++ b/os/board/packages-matrix.groovy
@@ -21,7 +21,7 @@ properties([
     ])
 ])
 
-node('coreos && sudo') {
+node('coreos && amd64 && sudo') {
     ws("${env.WORKSPACE}/${params.BOARD}") {
         stage('Build') {
             step([$class: 'CopyArtifact',

--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -80,7 +80,7 @@ for (group in group_map[params.COREOS_OFFICIAL]) {
         def FORMAT = format  /* This MUST use fresh variables per iteration.  */
 
         matrix_map["${GROUP}-${FORMAT}"] = {
-            node('coreos && sudo') {
+            node('coreos && amd64 && sudo') {
                 step([$class: 'CopyArtifact',
                       fingerprintArtifacts: true,
                       projectName: '/mantle/master-builder',

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -21,7 +21,7 @@ properties([
     ])
 ])
 
-node('kvm && !arm64') {
+node('amd64 && kvm') {
     stage('Build') {
         step([$class: 'CopyArtifact',
               fingerprintArtifacts: true,

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -22,7 +22,7 @@ https://wiki.cyanogenmod.org/w/Doc:_Using_manifests#The_local_manifest"""),
 
 def dprops = [:]  /* Store properties read from an artifact later.  */
 
-node('coreos && sudo') {
+node('coreos && amd64 && sudo') {
     stage('SCM') {
         checkout scm: [
             $class: 'GitSCM',

--- a/os/sdk.groovy
+++ b/os/sdk.groovy
@@ -24,7 +24,7 @@ properties([
     ])
 ])
 
-node('coreos && sudo') {
+node('coreos && amd64 && sudo') {
     stage('Build') {
         step([$class: 'CopyArtifact',
               fingerprintArtifacts: true,

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -24,7 +24,7 @@ properties([
     ])
 ])
 
-node('coreos && sudo') {
+node('coreos && amd64 && sudo') {
     stage('Build') {
         step([$class: 'CopyArtifact',
               fingerprintArtifacts: true,


### PR DESCRIPTION
The first patch, ```Specify sdk as node constraint```, is the only one we really need, which allows for arm64 nodes.  It will require you to add a label 'sdk' to your jenkins nodes.

The other patches are just minor feature improvements. 