### PR TITLE
for-merge-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To initialize all job properties (parameters, timers, etc.) from the Groovy scri
   - `os/glsa` compares security advisories against current upstream Gentoo.
   - `os/nightly-build` triggers every other OS job.
 
+### Nodes
+
+For ARM64 nodes the JDK must be installed manually by extracting the ARM64 JDK tarball on the node.  The JDK must either be installed to one of the Jenkins JDK search paths, `/home/$USER/jdk` for example, or the node environment variable `$JAVA_HOME` must be set.
+
 ## Usage
 
 By default, the nightly build and other OS job parameters always build from the `master` branches of both this and the manifest repositories. To build a Container Linux release, build the `os/manifest` job and set the `MANIFEST_REF` parameter to the release tag. To pull all Groovy scripts for an OS build from a different branch of this repository, set the `PIPELINE_BRANCH` parameter on the `os/manifest` job.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ To get started, a fresh Jenkins server can be run in a container.
 docker run -p 8080:8080 -p 50000:50000 jenkins
 ```
 
+### Plugins
+
+At a minimum, install the following Jenkins plugins:
+
+  - Config File Provider
+  - Folders
+  - Git
+  - Pipeline
+
+## Job Installation
+
 When the server is accessible, go to *Manage Jenkins* and *Script Console*. The contents of the file `init.groovy` can be pasted directly into the text box on this page to install all of the Container Linux OS jobs.
 
 To initialize all job properties (parameters, timers, etc.) from the Groovy scripts, the following should each be built once manually:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At a minimum, install the following Jenkins plugins:
   - Folders
   - Git
   - Pipeline
+  - Slack (Optional, install to get slack notifications.)
 
 ## Job Installation
 

--- a/os/board/image-matrix.groovy
+++ b/os/board/image-matrix.groovy
@@ -32,10 +32,10 @@ node('coreos && amd64 && sudo') {
 
             withCredentials([
                 [$class: 'FileBinding',
-                 credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+                 credentialsId: 'GPG_SECRET_KEY_FILE',
                  variable: 'GPG_SECRET_KEY_FILE'],
                 [$class: 'FileBinding',
-                 credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                 credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                  variable: 'GOOGLE_APPLICATION_CREDENTIALS']
             ]) {
                 withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/board/packages-matrix.groovy
+++ b/os/board/packages-matrix.groovy
@@ -32,7 +32,7 @@ node('coreos && amd64 && sudo') {
 
             withCredentials([
                 [$class: 'FileBinding',
-                 credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                 credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                  variable: 'GOOGLE_APPLICATION_CREDENTIALS']
             ]) {
                 withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -33,10 +33,10 @@ When all boot loader files are uploaded, go to ${BUILD_URL}input and proceed wit
 stage('Amend') {
     withCredentials([
         [$class: 'FileBinding',
-         credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+         credentialsId: 'GPG_SECRET_KEY_FILE',
          variable: 'GPG_SECRET_KEY_FILE'],
         [$class: 'FileBinding',
-         credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+         credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
          variable: 'GOOGLE_APPLICATION_CREDENTIALS']
     ]) {
         withEnv(["MANIFEST_NAME=${params.MANIFEST_NAME}",

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -21,8 +21,12 @@ properties([
 
 stage('Wait') {
     def version = params.MANIFEST_REF?.startsWith('refs/tags/v') ? params.MANIFEST_REF.substring(11) : ''
-    slackSend color: '#C0C0C0', message: """The ${params.BOARD} ${version ?: "UNKNOWN"} build is waiting for the boot loader files to be signed for Secure Boot and uploaded to https://console.cloud.google.com/storage/browser/builds.release.core-os.net/signed/boards/${params.BOARD}/${version} to continue.\n
+    def msg = """The ${params.BOARD} ${version ?: "UNKNOWN"} build is waiting for the boot loader files to be signed for Secure Boot and uploaded to https://console.cloud.google.com/storage/browser/builds.release.core-os.net/signed/boards/${params.BOARD}/${version} to continue.\n
 When all boot loader files are uploaded, go to ${BUILD_URL}input and proceed with the build."""
+
+    echo "${msg}"
+    if (Jenkins.instance.pluginManager.getPlugin("slack"))
+        slackSend color: '#C0C0C0', message: "${msg}"
     input 'Waiting for the signed UEFI binaries to be ready...'
 }
 

--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -89,10 +89,10 @@ for (group in group_map[params.COREOS_OFFICIAL]) {
 
                 withCredentials([
                     [$class: 'FileBinding',
-                     credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+                     credentialsId: 'GPG_SECRET_KEY_FILE',
                      variable: 'GPG_SECRET_KEY_FILE'],
                     [$class: 'FileBinding',
-                     credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                     credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                      variable: 'GOOGLE_APPLICATION_CREDENTIALS']
                 ]) {
                     withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -31,7 +31,7 @@ node('amd64 && kvm') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["BOARD=${params.BOARD}",

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -50,7 +50,7 @@ node('coreos && amd64 && sudo') {
                          fallbackToLastSuccessful: true,
                          upstreamFilterStrategy: 'UseGlobalSetting']])
 
-        sshagent(['3d4319c2-bca1-47c8-a483-2f355c249e30']) {
+        sshagent(['MANIFEST_BUILDS_KEY']) {
             /* Work around JENKINS-35230 (broken GIT_* variables).  */
             withEnv(['GIT_BRANCH=' + (sh(returnStdout: true, script: "git -C manifest tag -l ${params.MANIFEST_REF}").trim() ? params.MANIFEST_REF : "origin/${params.MANIFEST_REF}"),
                      'GIT_COMMIT=' + sh(returnStdout: true, script: 'git -C manifest rev-parse HEAD').trim(),

--- a/os/sdk.groovy
+++ b/os/sdk.groovy
@@ -36,10 +36,10 @@ node('coreos && amd64 && sudo') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+             credentialsId: 'GPG_SECRET_KEY_FILE',
              variable: 'GPG_SECRET_KEY_FILE'],
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -36,10 +36,10 @@ node('coreos && amd64 && sudo') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+             credentialsId: 'GPG_SECRET_KEY_FILE',
              variable: 'GPG_SECRET_KEY_FILE'],
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",


### PR DESCRIPTION
A second set of patches toward making the jobs more generic.

With the patch 'Use generic values for credential IDs' you'll need to create new Jenkins credentials with IDs `GPG_SECRET_KEY_FILE`, `GOOGLE_APPLICATION_CREDENTIALS` and `MANIFEST_BUILDS_KEY`.