### PR TITLE
for-merge-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To initialize all job properties (parameters, timers, etc.) from the Groovy scri
   - `os/glsa` compares security advisories against current upstream Gentoo.
   - `os/nightly-build` triggers every other OS job.
 
+### Nodes
+
+For ARM64 nodes the JDK must be installed manually by extracting the ARM64 JDK tarball on the node.  The JDK must either be installed to one of the Jenkins JDK search paths, `/home/$USER/jdk` for example, or the node environment variable `$JAVA_HOME` must be set.
+
 ## Usage
 
 By default, the nightly build and other OS job parameters always build from the `master` branches of both this and the manifest repositories. To build a Container Linux release, build the `os/manifest` job and set the `MANIFEST_REF` parameter to the release tag. To pull all Groovy scripts for an OS build from a different branch of this repository, set the `PIPELINE_BRANCH` parameter on the `os/manifest` job.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ To get started, a fresh Jenkins server can be run in a container.
 docker run -p 8080:8080 -p 50000:50000 jenkins
 ```
 
+### Plugins
+
+At a minimum, install the following Jenkins plugins:
+
+  - Config File Provider
+  - Folders
+  - Git
+  - Pipeline
+
+## Job Installation
+
 When the server is accessible, go to *Manage Jenkins* and *Script Console*. The contents of the file `init.groovy` can be pasted directly into the text box on this page to install all of the Container Linux OS jobs.
 
 To initialize all job properties (parameters, timers, etc.) from the Groovy scripts, the following should each be built once manually:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At a minimum, install the following Jenkins plugins:
   - Folders
   - Git
   - Pipeline
+  - Slack (Optional, install to get slack notifications.)
 
 ## Job Installation
 

--- a/os/board/image-matrix.groovy
+++ b/os/board/image-matrix.groovy
@@ -32,10 +32,10 @@ node('coreos && amd64 && sudo') {
 
             withCredentials([
                 [$class: 'FileBinding',
-                 credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+                 credentialsId: 'GPG_SECRET_KEY_FILE',
                  variable: 'GPG_SECRET_KEY_FILE'],
                 [$class: 'FileBinding',
-                 credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                 credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                  variable: 'GOOGLE_APPLICATION_CREDENTIALS']
             ]) {
                 withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/board/packages-matrix.groovy
+++ b/os/board/packages-matrix.groovy
@@ -32,7 +32,7 @@ node('coreos && amd64 && sudo') {
 
             withCredentials([
                 [$class: 'FileBinding',
-                 credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                 credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                  variable: 'GOOGLE_APPLICATION_CREDENTIALS']
             ]) {
                 withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -21,11 +21,19 @@ properties([
 
 node('coreos && amd64') {
     def config
+    String verify_key = "./verify_key"
 
     stage('Config') {
         configFileProvider([configFile(fileId: 'JOB_CONFIG', variable: 'JOB_CONFIG')]) {
             sh "cat ${env.JOB_CONFIG}"
             config = load("${env.JOB_CONFIG}")
+        }
+        try {
+            configFileProvider([configFile(fileId: 'GPG_VERIFY_KEY', targetLocation: "${verify_key}")]) {
+            }
+        } catch (err) {
+            echo "Using build-in GPG verify key."
+            verify_key = ""
         }
     }
 
@@ -63,7 +71,8 @@ When all boot loader files are uploaded, go to ${BUILD_URL}input and proceed wit
                     "BOARD=${params.BOARD}",
                     "DEV_BUILDS_ROOT=${config.DEV_BUILDS_ROOT()}",
                     "REL_BUILDS_ROOT=${config.DEV_BUILDS_ROOT()}",
-                    "GPG_USER_ID=${config.GPG_USER_ID()}"]) {
+                    "GPG_USER_ID=${config.GPG_USER_ID()}",
+                    "GPG_VERIFY_KEY=${verify_key}"]) {
                 sh '''#!/bin/bash -ex
 
 sudo rm -rf gce.properties src tmp
@@ -108,6 +117,7 @@ UPLOAD=gs://${REL_BUILDS_ROOT}  # /alpha, /beta, /stable
 mkdir -p src tmp
 ./bin/cork download-image --root="${DOWNLOAD}/unsigned/boards/${BOARD}/${COREOS_VERSION}" \
                           --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
+                          --verify-key="${GPG_VERIFY_KEY}" \
                           --cache-dir=./src \
                           --platform=qemu
 img=src/coreos_production_image.bin

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -33,10 +33,10 @@ When all boot loader files are uploaded, go to ${BUILD_URL}input and proceed wit
 stage('Amend') {
     withCredentials([
         [$class: 'FileBinding',
-         credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+         credentialsId: 'GPG_SECRET_KEY_FILE',
          variable: 'GPG_SECRET_KEY_FILE'],
         [$class: 'FileBinding',
-         credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+         credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
          variable: 'GOOGLE_APPLICATION_CREDENTIALS']
     ]) {
         withEnv(["MANIFEST_NAME=${params.MANIFEST_NAME}",

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -21,8 +21,12 @@ properties([
 
 stage('Wait') {
     def version = params.MANIFEST_REF?.startsWith('refs/tags/v') ? params.MANIFEST_REF.substring(11) : ''
-    slackSend color: '#C0C0C0', message: """The ${params.BOARD} ${version ?: "UNKNOWN"} build is waiting for the boot loader files to be signed for Secure Boot and uploaded to https://console.cloud.google.com/storage/browser/builds.release.core-os.net/signed/boards/${params.BOARD}/${version} to continue.\n
+    def msg = """The ${params.BOARD} ${version ?: "UNKNOWN"} build is waiting for the boot loader files to be signed for Secure Boot and uploaded to https://console.cloud.google.com/storage/browser/builds.release.core-os.net/signed/boards/${params.BOARD}/${version} to continue.\n
 When all boot loader files are uploaded, go to ${BUILD_URL}input and proceed with the build."""
+
+    echo "${msg}"
+    if (Jenkins.instance.pluginManager.getPlugin("slack"))
+        slackSend color: '#C0C0C0', message: "${msg}"
     input 'Waiting for the signed UEFI binaries to be ready...'
 }
 

--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -82,11 +82,19 @@ for (group in group_map[params.COREOS_OFFICIAL]) {
         matrix_map["${GROUP}-${FORMAT}"] = {
             node('coreos && amd64 && sudo') {
                 def config
+                String verify_key = "./verify_key"
 
                 stage('Config') {
                     configFileProvider([configFile(fileId: 'JOB_CONFIG', variable: 'JOB_CONFIG')]) {
                         sh "cat ${env.JOB_CONFIG}"
                         config = load("${env.JOB_CONFIG}")
+                    }
+                    try {
+                        configFileProvider([configFile(fileId: 'GPG_VERIFY_KEY', targetLocation: "${verify_key}")]) {
+                        }
+                    } catch (err) {
+                        echo "Using build-in GPG verify key."
+                        verify_key = ""
                     }
                 }
 
@@ -114,7 +122,8 @@ for (group in group_map[params.COREOS_OFFICIAL]) {
                              "DEV_BUILDS_ROOT=${config.DEV_BUILDS_ROOT()}",
                              "DOWNLOAD_ROOT=${config.DOWNLOAD_ROOT()}",
                              "REL_BUILDS_ROOT=${config.REL_BUILDS_ROOT()}",
-                             "GPG_USER_ID=${config.GPG_USER_ID()}"]) {
+                             "GPG_USER_ID=${config.GPG_USER_ID()}",
+                             "GPG_VERIFY_KEY=${verify_key}"]) {
                         sh '''#!/bin/bash -ex
 
 rm -f gce.properties
@@ -167,6 +176,7 @@ fi
 mkdir -p src tmp
 ./bin/cork download-image --root="${root}/boards/${BOARD}/${COREOS_VERSION}" \
                           --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
+                          --verify-key="${GPG_VERIFY_KEY}" \
                           --cache-dir=./src \
                           --platform=qemu
 img=src/coreos_production_image.bin

--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -89,10 +89,10 @@ for (group in group_map[params.COREOS_OFFICIAL]) {
 
                 withCredentials([
                     [$class: 'FileBinding',
-                     credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+                     credentialsId: 'GPG_SECRET_KEY_FILE',
                      variable: 'GPG_SECRET_KEY_FILE'],
                     [$class: 'FileBinding',
-                     credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+                     credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
                      variable: 'GOOGLE_APPLICATION_CREDENTIALS']
                 ]) {
                     withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -31,7 +31,7 @@ node('amd64 && kvm') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["BOARD=${params.BOARD}",

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -50,7 +50,7 @@ node('coreos && amd64 && sudo') {
                          fallbackToLastSuccessful: true,
                          upstreamFilterStrategy: 'UseGlobalSetting']])
 
-        sshagent(['3d4319c2-bca1-47c8-a483-2f355c249e30']) {
+        sshagent(['MANIFEST_BUILDS_KEY']) {
             /* Work around JENKINS-35230 (broken GIT_* variables).  */
             withEnv(['GIT_BRANCH=' + (sh(returnStdout: true, script: "git -C manifest tag -l ${params.MANIFEST_REF}").trim() ? params.MANIFEST_REF : "origin/${params.MANIFEST_REF}"),
                      'GIT_COMMIT=' + sh(returnStdout: true, script: 'git -C manifest rev-parse HEAD').trim(),

--- a/os/sdk.groovy
+++ b/os/sdk.groovy
@@ -36,10 +36,10 @@ node('coreos && amd64 && sudo') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+             credentialsId: 'GPG_SECRET_KEY_FILE',
              variable: 'GPG_SECRET_KEY_FILE'],
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -36,10 +36,10 @@ node('coreos && amd64 && sudo') {
 
         withCredentials([
             [$class: 'FileBinding',
-             credentialsId: 'buildbot-official.2E16137F.subkey.gpg',
+             credentialsId: 'GPG_SECRET_KEY_FILE',
              variable: 'GPG_SECRET_KEY_FILE'],
             [$class: 'FileBinding',
-             credentialsId: 'jenkins-coreos-systems-write-5df31bf86df3.json',
+             credentialsId: 'GOOGLE_APPLICATION_CREDENTIALS',
              variable: 'GOOGLE_APPLICATION_CREDENTIALS']
         ]) {
             withEnv(["COREOS_OFFICIAL=${params.COREOS_OFFICIAL}",

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -25,6 +25,15 @@ properties([
 ])
 
 node('coreos && amd64 && sudo') {
+    def config
+
+    stage('Config') {
+        configFileProvider([configFile(fileId: 'JOB_CONFIG', variable: 'JOB_CONFIG')]) {
+            sh "cat ${env.JOB_CONFIG}"
+            config = load("${env.JOB_CONFIG}")
+        }
+    }
+
     stage('Build') {
         step([$class: 'CopyArtifact',
               fingerprintArtifacts: true,
@@ -46,7 +55,9 @@ node('coreos && amd64 && sudo') {
                      "MANIFEST_NAME=${params.MANIFEST_NAME}",
                      "MANIFEST_REF=${params.MANIFEST_REF}",
                      "MANIFEST_URL=${params.MANIFEST_URL}",
-                     'USE_CACHE=' + (params.USE_CACHE ? 'true' : 'false')]) {
+                     'USE_CACHE=' + (params.USE_CACHE ? 'true' : 'false'),
+                     "DEV_BUILDS_ROOT=${config.DEV_BUILDS_ROOT()}",
+                     "GPG_USER_ID=${config.GPG_USER_ID()}"]) {
                 sh '''#!/bin/bash -ex
 
 # build may not be started without a ref value
@@ -61,7 +72,14 @@ node('coreos && amd64 && sudo') {
                   --manifest-name "${MANIFEST_NAME}"
 
 enter() {
-  ./bin/cork enter --experimental -- "$@"
+  ./bin/cork enter --experimental -- env \
+    COREOS_DEV_BUILDS="http://storage.googleapis.com/${DEV_BUILDS_ROOT}" \
+    "$@"
+}
+
+script() {
+  local script="/mnt/host/source/src/scripts/${1}"; shift
+  enter "${script}" "$@"
 }
 
 source .repo/manifests/version.txt
@@ -83,8 +101,8 @@ fi
 S=/mnt/host/source/src/scripts
 enter sudo emerge -uv --jobs=2 catalyst
 enter sudo ${S}/build_toolchains \
-  --sign buildbot@coreos.com --sign_digests buildbot@coreos.com \
-  --upload --upload_root gs://builds.developer.core-os.net
+  --sign ${GPG_USER_ID} --sign_digests ${GPG_USER_ID} \
+  --upload --upload_root gs://${DEV_BUILDS_ROOT}
 
 # Free some disk space only on success, for debugging failures
 sudo rm -rf src/build/catalyst/builds

--- a/sample-job-config.groovy
+++ b/sample-job-config.groovy
@@ -1,0 +1,47 @@
+#!groovy
+
+/*
+ * Default Jenkins job config file.
+ */
+
+/*
+ * CL_MANIFEST_URL - Git repository of the Container Linux manifest.
+ */
+def CL_MANIFEST_URL() {'https://github.com/coreos/manifest.git'}
+
+/*
+ * DEV_BUILDS_ROOT - Google storage bucket for Jenkins developer artifacts.
+ */
+def DEV_BUILDS_ROOT() {'builds.developer.core-os.net'}
+
+/*
+ * DOWNLOAD_ROOT - Download URL of official Container Linux releases.
+ */
+def DOWNLOAD_ROOT() {'release.core-os.net'}
+
+/*
+ *  GIT_AUTHOR_EMAIL - Jenkins commit author.
+ */
+def GIT_AUTHOR_EMAIL() {'jenkins@jenkins.coreos.systems'}
+
+/*
+ *  GIT_AUTHOR_NAME - Jenkins commit author.
+ */
+def GIT_AUTHOR_NAME() {'CoreOS Jenkins'}
+
+/*
+ * GPG_USER_ID - User ID for the Jenkins GPG_SECRET_KEY_FILE credential.
+ */
+def GPG_USER_ID() {'buildbot@coreos.com'}
+
+/*
+ * MANIFEST_BUILDS_URL - Git repository for Jenkins manifest-builds.
+ */
+def MANIFEST_BUILDS_URL() {'https://github.com/coreos/manifest-builds.git'}
+
+/*
+ * REL_BUILDS_ROOT - Google storage bucket for Jenkins release artifacts.
+ */
+def REL_BUILDS_ROOT() {'builds.release.core-os.net'}
+
+return this


### PR DESCRIPTION
A third set of patches toward making the jobs more generic.

This series uses the Jenkins Config File Provider plugin to have a job config file that holds the site specific parameters. 

Depends on https://github.com/coreos/jenkins-os/pull/2 (for-merge-2).