### PR TITLE
vm-matrix: Enable arm64 packet build

### DIFF
--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -61,6 +61,7 @@ qemu_uefi
 pxe
 openstack
 openstack_mini
+packet
 ''']
 
 /* The group list mapping is keyed on ${COREOS_OFFICIAL}.  */


### PR DESCRIPTION
Depends on https://github.com/coreos/coreos-overlay/pull/2482.

cc @vielmetti