### PR TITLE
os/kola/gce: Use a saved version.txt instead of fetching from Git

### DIFF
--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -261,12 +261,8 @@ stage('Downstream') {
         'kola-gce': {
             if (params.BOARD == 'amd64-usr')
                 build job: '../kola/gce', propagate: false, parameters: [
-                    string(name: 'BUILDS_CLONE_CREDS', value: params.BUILDS_CLONE_CREDS),
-                    string(name: 'MANIFEST_TAG', value: params.MANIFEST_TAG),
-                    string(name: 'MANIFEST_URL', value: params.MANIFEST_URL),
                     string(name: 'GS_RELEASE_CREDS', value: params.GS_RELEASE_CREDS),
                     string(name: 'GS_RELEASE_ROOT', value: params.GS_RELEASE_ROOT),
-                    text(name: 'VERIFY_KEYRING', value: params.VERIFY_KEYRING),
                     string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH)
                 ]
         },

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -229,7 +229,8 @@ finish "${COREOS_BUILD_ID}"
     }
 
     stage('Post-build') {
-        archiveArtifacts 'manifest.properties,manifest/version.txt'
+        archiveArtifacts artifacts: 'manifest.properties,manifest/version.txt',
+                         fingerprint: true
 
         for (line in readFile('manifest.properties').trim().split("\n")) {
             def tokens = line.tokenize(" =")


### PR DESCRIPTION
@euank  I think this is what you wanted to do with AWS.  It uses the `version.txt` artifact instead of fetching it from a remote repo since the SDK chroot isn't needed in this job.

Also note that this will break replay builds, since they won't have upstream build triggers.  It will still work with regular rebuilds.