### PR TITLE
os/kola/aws: Pass --aws-region to "kola run"

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -58,6 +58,7 @@ timeout --signal=SIGQUIT 30m bin/kola run \
     --parallel=4 \
     --basename="${NAME}" \
     --aws-ami="${AWS_AMI_ID}" \
+    --aws-region="${AWS_REGION}" \
     --aws-type="${instance_type}" \
     --platform=aws \
     --tapfile="${JOB_NAME##*/}.tap"


### PR DESCRIPTION
kola will read the region from `AWS_REGION`, but that's confusing when rerunning a test by manually copying the kola command line from the log.