### PR TITLE
kola/{aws,gce}: increase timeout

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -54,7 +54,7 @@ if [[ "${AWS_AMI_TYPE}" == "PV" ]]; then
     instance_type="m1.small"
 fi
 
-timeout --signal=SIGQUIT 30m bin/kola run \
+timeout --signal=SIGQUIT 60m bin/kola run \
     --parallel=4 \
     --basename="${NAME}" \
     --aws-ami="${AWS_AMI_ID}" \

--- a/os/kola/gce.groovy
+++ b/os/kola/gce.groovy
@@ -83,7 +83,7 @@ bin/ore gcloud create-image \
 
 GCE_NAME="${NAME//[+.]/-}-${COREOS_VERSION//[+.]/-}"
 
-timeout --signal=SIGQUIT 30m bin/kola run \
+timeout --signal=SIGQUIT 60m bin/kola run \
     --gce-image="${GCE_NAME}" \
     --gce-json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --parallel=4 \


### PR DESCRIPTION
This matches the qemu timeout. In practice, aws runs seem to be brushing
against the timeout. GCE runs don't, but I think it's reasonable to keep
it consistent with the other timeouts.