### PR TITLE
kola/aws: Test PV instances on m3.medium

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -51,7 +51,7 @@ NAME="jenkins-${JOB_NAME##*/}-${BUILD_NUMBER}"
 
 instance_type="t2.small"
 if [[ "${AWS_AMI_TYPE}" == "PV" ]]; then
-    instance_type="m1.small"
+    instance_type="m3.medium"
 fi
 
 timeout --signal=SIGQUIT 60m bin/kola run \


### PR DESCRIPTION
`m1.small` produces a bunch of intermittent problems we're not going to debug right now.