### PR TITLE
Read OS build scripts from the scripts repository

### DIFF
--- a/os/docs-sync.groovy
+++ b/os/docs-sync.groovy
@@ -116,10 +116,10 @@ git -C coreos-pages commit -am 'os: prune old releases' || :
 
         stage('Sync') {
             if (params.LATEST == 'auto')
-                latest = 0 == sh returnStatus: true, script: """#!/bin/bash -ex
+                latest = 0 == sh(returnStatus: true, script: """#!/bin/bash -ex
 curl -Ls '${api}' | { jq -r .items[].version ; echo '${version}' ; } |
 sort -ruV | head -1 | grep -Fqx '${version}'
-"""  /* Editor quote safety: " */
+""")  /* Editor quote safety: " */
 
             withCredentials([
                 [$class: 'FileBinding',

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -269,21 +269,21 @@ rm -f message.txt
 repos=( coreos/coreos-overlay coreos/portage-stable coreos/scripts )
 
 declare -A new=()
-git -C .repo/manifests checkout "${MANIFEST_REF}"
+git -C manifest checkout "${MANIFEST_REF}"
 for repo in "${repos[@]}"
 do
-        new[${repo}]=$(sed -n 's/.* name="'${repo}'".* revision="\\([^"]*\\)".*/\\1/p' ".repo/manifests/${MANIFEST_NAME}")
+        new[${repo}]=$(sed -n 's,.* name="'${repo}'".* revision="\\([^"]*\\)".*,\\1,p' "manifest/${MANIFEST_NAME}")
 done
 
 declare -A old=()
-git -C .repo/manifests checkout HEAD^
+git -C manifest checkout HEAD^
 for repo in "${repos[@]}"
 do
-        old[${repo}]=$(sed -n 's/.* name="'${repo}'".* revision="\\([^"]*\\)".*/\\1/p' ".repo/manifests/${MANIFEST_NAME}")
+        old[${repo}]=$(sed -n 's,.* name="'${repo}'".* revision="\\([^"]*\\)".*,\\1,p' "manifest/${MANIFEST_NAME}")
 done
 
 echo "${MANIFEST_REF#v} - ${BUILD_URL}cldsv" > message.txt
-echo "${MANIFEST_URL%.git}/commit/$(git -C .repo/manifests rev-list --max-count=1 "${MANIFEST_REF}")" >> message.txt
+echo "${MANIFEST_URL%.git}/commit/$(git -C manifest rev-list --max-count=1 "${MANIFEST_REF}")" >> message.txt
 for repo in "${repos[@]}"
 do
         [ -z "${new[${repo}]}" -o "x${new[${repo}]}" == "x${old[${repo}]}" ] ||

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -283,11 +283,11 @@ do
 done
 
 echo "${MANIFEST_REF#v} - ${BUILD_URL}cldsv" > message.txt
-echo "${MANIFEST_URL%.git}/commit/$(git -C manifest rev-list --max-count=1 "${MANIFEST_REF}")" >> message.txt
+echo "${MANIFEST_URL%.git}/commit/$(git -C manifest rev-list --max-count=1 "${MANIFEST_REF}" | head -c 10)" >> message.txt
 for repo in "${repos[@]}"
 do
         [ -z "${new[${repo}]}" -o "x${new[${repo}]}" == "x${old[${repo}]}" ] ||
-        echo "https://github.com/${repo}/compare/${old[${repo}]}...${new[${repo}]}" >> message.txt
+        echo "https://github.com/${repo}/compare/${old[${repo}]:0:10}...${new[${repo}]:0:10}" >> message.txt
 done
 '''  /* Editor quote safety: ' */
             }

--- a/os/sdk.groovy
+++ b/os/sdk.groovy
@@ -81,49 +81,28 @@ node('coreos && amd64 && sudo') {
                          "UPLOAD_ROOT=${params.GS_DEVEL_ROOT}"]) {
                     sh '''#!/bin/bash -ex
 
-# build may not be started without a ref value
-[[ -n "${MANIFEST_TAG}" ]]
+# The build may not be started without a tag value.
+[ -n "${MANIFEST_TAG}" ]
 
-# hack because catalyst leaves things chowned as root
-[[ -d .cache/sdks ]] && sudo chown -R $USER .cache/sdks
+# Catalyst leaves things chowned as root.
+[ -d .cache/sdks ] && sudo chown -R "$USER" .cache/sdks
 
-# set up GPG for verifying tags
+# Set up GPG for verifying tags.
 export GNUPGHOME="${PWD}/.gnupg"
 rm -rf "${GNUPGHOME}"
-trap "rm -rf '${GNUPGHOME}'" EXIT
+trap 'rm -rf "${GNUPGHOME}"' EXIT
 mkdir --mode=0700 "${GNUPGHOME}"
 gpg --import verify.asc
 
-./bin/cork update --create --downgrade-replace --verify --verify-signature --verbose \
-                  --manifest-url "${MANIFEST_URL}" \
-                  --manifest-branch "refs/tags/${MANIFEST_TAG}" \
-                  --manifest-name "${MANIFEST_NAME}"
+bin/cork update \
+    --create --downgrade-replace --verify --verify-signature --verbose \
+    --manifest-branch "refs/tags/${MANIFEST_TAG}" \
+    --manifest-name "${MANIFEST_NAME}" \
+    --manifest-url "${MANIFEST_URL}"
 
-enter() {
-    ./bin/cork enter --experimental -- "$@"
-}
-
-source .repo/manifests/version.txt
-export COREOS_BUILD_ID
-
-# Set up GPG for signing images
-gpg --import "${GPG_SECRET_KEY_FILE}"
-
-# Wipe all of catalyst
-sudo rm -rf src/build
-
-S=/mnt/host/source/src/scripts
-enter ${S}/update_chroot
-enter sudo emerge -uv --jobs=2 catalyst
-enter sudo ${S}/bootstrap_sdk \
-    --sign="${SIGNING_USER}" \
-    --sign_digests="${SIGNING_USER}" \
-    --upload_root="${UPLOAD_ROOT}" \
-    --upload
-
-# Free some disk space only on success, for debugging failures
-sudo rm -rf src/build/catalyst/builds
-'''  /* Editor quote safety: ' */
+# Run branch-specific build commands from the scripts repository.
+. src/scripts/jenkins/sdk.sh
+'''
                 }
             }
         }


### PR DESCRIPTION
This allows branching the scripts' execution at build time along with the options that branch supports.  It also allows branching the list of image formats produced during a release.