### PR TITLE
os/docs-sync: Use new docs data for pruning releases

### DIFF
--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -127,6 +127,7 @@ def downstreams = [
     },
     'packet': { if (params.BOARD == 'amd64-usr')
         build job: '../kola/packet', wait: false, parameters: [
+            string(name: 'BOARD', value: params.BOARD),
             credentials(name: 'BUILDS_CLONE_CREDS', value: params.BUILDS_CLONE_CREDS),
             credentials(name: 'DOWNLOAD_CREDS', value: params.GS_RELEASE_CREDS),
             string(name: 'DOWNLOAD_ROOT', value: params.GS_RELEASE_ROOT),

--- a/os/kola/packet.groovy
+++ b/os/kola/packet.groovy
@@ -4,6 +4,9 @@ properties([
     buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '50')),
 
     parameters([
+        choice(name: 'BOARD',
+               choices: "amd64-usr\narm64-usr",
+               description: 'Target board to build'),
         credentials(credentialType: 'com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey',
                     defaultValue: '',
                     description: 'Credential ID for SSH Git clone URLs',
@@ -67,7 +70,7 @@ node('coreos && amd64 && sudo') {
                 string(credentialsId: params.PACKET_CREDS, variable: 'PACKET_API_KEY'),
                 file(credentialsId: params.UPLOAD_CREDS, variable: 'UPLOAD_CREDS'),
             ]) {
-                withEnv(["BOARD=amd64-usr",
+                withEnv(["BOARD=${params.BOARD}",
                          "DOWNLOAD_ROOT=${params.DOWNLOAD_ROOT}",
                          "MANIFEST_NAME=${params.MANIFEST_NAME}",
                          "MANIFEST_TAG=${params.MANIFEST_TAG}",


### PR DESCRIPTION
I'm just pushing this now in preparation for coreos-inc/coreos-pages#1717.