### PR TITLE
os/kola: Set instance basename on GCE and Packet

### DIFF
--- a/os/kola/gce.groovy
+++ b/os/kola/gce.groovy
@@ -54,6 +54,7 @@ bin/ore gcloud create-image \
 GCE_NAME="${NAME//[+.]/-}-${COREOS_VERSION//[+.]/-}"
 
 timeout --signal=SIGQUIT 60m bin/kola run \
+    --basename="${NAME}" \
     --gce-image="${GCE_NAME}" \
     --gce-json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --parallel=4 \

--- a/os/kola/packet.groovy
+++ b/os/kola/packet.groovy
@@ -81,6 +81,9 @@ node('coreos && amd64 && sudo') {
 
 rm -rf *.tap _kola_temp* url.txt
 
+# JOB_NAME will not fit within the character limit
+NAME="jenkins-${BUILD_NUMBER}"
+
 # Set up GPG for verifying tags.
 export GNUPGHOME="${PWD}/.gnupg"
 rm -rf "${GNUPGHOME}"
@@ -105,6 +108,7 @@ bin/cork enter --experimental -- gsutil signurl -d "${timeout}" \
 sed -n 's,^.*https://,https://,p' > url.txt
 
 timeout --signal=SIGQUIT "${timeout}" bin/kola run \
+    --basename="${NAME}" \
     --board="${BOARD}" \
     --gce-json-key="${UPLOAD_CREDS}" \
     --packet-api-key="${PACKET_API_KEY}" \


### PR DESCRIPTION
Make it easier to distinguish Jenkins-spawned instances from manual kola runs.