### PR TITLE
*: add torcx download root

### DIFF
--- a/os/board/image-matrix.groovy
+++ b/os/board/image-matrix.groovy
@@ -80,6 +80,9 @@ Google Storage URL, requires write permission''',
         string(name: 'SIGNING_USER',
                defaultValue: 'buildbot@coreos.com',
                description: 'E-mail address to identify the GPG key'),
+        string(name: 'TORCX_PKG_DOWNLOAD_ROOT',
+               defaultValue: 'gs://builds.developer.core-os.net',
+               description: 'URL from which tectonic torcx pkgs are downloaded by jenkins'),
         text(name: 'VERIFY_KEYRING',
              defaultValue: '',
              description: '''ASCII-armored keyring containing the public keys \
@@ -124,6 +127,7 @@ node('coreos && amd64 && sudo') {
                          "MANIFEST_TAG=${params.MANIFEST_TAG}",
                          "MANIFEST_URL=${params.MANIFEST_URL}",
                          "SIGNING_USER=${params.SIGNING_USER}",
+                         "TORCX_PKG_DOWNLOAD_ROOT=${params.TORCX_PKG_DOWNLOAD_ROOT}",
                          "UPLOAD_ROOT=${UPLOAD_ROOT}"]) {
                     sh '''#!/bin/bash -ex
 

--- a/os/board/packages-matrix.groovy
+++ b/os/board/packages-matrix.groovy
@@ -83,6 +83,12 @@ Google Storage URL, requires write permission''',
         string(name: 'SIGNING_USER',
                defaultValue: 'buildbot@coreos.com',
                description: 'E-mail address to identify the GPG key'),
+        string(name: 'TECTONIC_TORCX_DOWNLOAD_ROOT',
+               defaultValue: 'http://builds.developer.core-os.net/torcx',
+               description: 'URL prefix where tectonic torcx pkgs are downloaded by users'),
+        string(name: 'TORCX_PKG_DOWNLOAD_ROOT',
+               defaultValue: 'gs://builds.developer.core-os.net/torcx',
+               description: 'URL prefix where tectonic torcx pkgs are downloaded by jenkins'),
         text(name: 'VERIFY_KEYRING',
              defaultValue: '',
              description: '''ASCII-armored keyring containing the public keys \
@@ -115,6 +121,8 @@ node('coreos && amd64 && sudo') {
                          "MANIFEST_URL=${params.MANIFEST_URL}",
                          "RELEASE_BASE=${params.RELEASE_BASE}",
                          "SIGNING_USER=${params.SIGNING_USER}",
+                         "TECTONIC_TORCX_DOWNLOAD_ROOT=${params.TECTONIC_TORCX_DOWNLOAD_ROOT}",
+                         "TORCX_PKG_DOWNLOAD_ROOT=${params.TORCX_PKG_DOWNLOAD_ROOT}",
                          "UPLOAD_ROOT=${params.GS_DEVEL_ROOT}"]) {
                     sh '''#!/bin/bash -ex
 
@@ -170,6 +178,7 @@ stage('Downstream') {
         string(name: 'PACKET_PROJECT', value: params.PACKET_PROJECT),
         credentials(name: 'SIGNING_CREDS', value: params.SIGNING_CREDS),
         string(name: 'SIGNING_USER', value: params.SIGNING_USER),
+        string(name: 'TORCX_PKG_DOWNLOAD_ROOT', value: params.TORCX_PKG_DOWNLOAD_ROOT),
         text(name: 'VERIFY_KEYRING', value: params.VERIFY_KEYRING),
         string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH)
     ]

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -324,6 +324,8 @@ stage('Downstream') {
                     string(name: 'RELEASE_BASE', value: releaseBase),
                     credentials(name: 'SIGNING_CREDS', value: profile.SIGNING_CREDS),
                     string(name: 'SIGNING_USER', value: profile.SIGNING_USER),
+                    string(name: 'TECTONIC_TORCX_DOWNLOAD_ROOT', value: profile.TECTONIC_TORCX_DOWNLOAD_ROOT),
+                    string(name: 'TORCX_PKG_DOWNLOAD_ROOT', value: profile.TORCX_PKG_DOWNLOAD_ROOT),
                     text(name: 'VERIFY_KEYRING', value: keyring),
                     string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH)
                 ]
@@ -370,6 +372,8 @@ stage('Downstream') {
                     string(name: 'PACKET_PROJECT', value: profile.PACKET_PROJECT),
                     credentials(name: 'SIGNING_CREDS', value: profile.SIGNING_CREDS),
                     string(name: 'SIGNING_USER', value: profile.SIGNING_USER),
+                    string(name: 'TECTONIC_TORCX_DOWNLOAD_ROOT', value: profile.TECTONIC_TORCX_DOWNLOAD_ROOT),
+                    string(name: 'TORCX_PKG_DOWNLOAD_ROOT', value: profile.TORCX_PKG_DOWNLOAD_ROOT),
                     text(name: 'VERIFY_KEYRING', value: keyring),
                     string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH)
                 ]

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -80,6 +80,12 @@ Google Storage URL, requires write permission''',
         string(name: 'SIGNING_USER',
                defaultValue: 'buildbot@coreos.com',
                description: 'E-mail address to identify the GPG key'),
+        string(name: 'TECTONIC_TORCX_DOWNLOAD_ROOT',
+               defaultValue: 'http://builds.developer.core-os.net/torcx',
+               description: 'URL prefix where tectonic torcx packages are downloaded'),
+        string(name: 'TORCX_PKG_DOWNLOAD_ROOT',
+               defaultValue: 'gs://builds.developer.core-os.net/torcx',
+               description: 'URL prefix where tectonic torcx pkgs are downloaded by jenkins'),
         text(name: 'VERIFY_KEYRING',
              defaultValue: '',
              description: '''ASCII-armored keyring containing the public keys \
@@ -175,6 +181,8 @@ stage('Downstream') {
                 string(name: 'RELEASE_BASE', value: ''),
                 credentials(name: 'SIGNING_CREDS', value: params.SIGNING_CREDS),
                 string(name: 'SIGNING_USER', value: params.SIGNING_USER),
+                string(name: 'TECTONIC_TORCX_DOWNLOAD_ROOT', value: params.TECTONIC_TORCX_DOWNLOAD_ROOT),
+                string(name: 'TORCX_PKG_DOWNLOAD_ROOT', value: params.TORCX_PKG_DOWNLOAD_ROOT),
                 text(name: 'VERIFY_KEYRING', value: params.VERIFY_KEYRING),
                 string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH)
             ]

--- a/resources/com/coreos/profiles/alpha.json
+++ b/resources/com/coreos/profiles/alpha.json
@@ -7,4 +7,6 @@
     "GROUP": "alpha",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://alpha.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/alpha",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/beta.json
+++ b/resources/com/coreos/profiles/beta.json
@@ -7,4 +7,6 @@
     "GROUP": "beta",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://beta.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/beta",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/developer.json
+++ b/resources/com/coreos/profiles/developer.json
@@ -61,6 +61,16 @@
     "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-5df31bf86df3.json",
 
     /*
+     * URLs from which to download torcx packages are embedded in torcx manifests.
+     * The "TECTONIC_TORCX_DOWNLOAD_ROOT" variable is that URL from which users may
+     * eventually download built torcx packages.
+     * The second, TORCX_PKG_DOWNLOAD_ROOT, is the location used by this
+     * jenkins to upload and download packages during torcx package and image build.
+     */
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "http://builds.developer.core-os.net/torcx",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://builds.developer.core-os.net/torcx",
+
+    /*
      * This is the URL cloned by the os/manifest job to read the base
      * manifest files that define the OS build.
      */

--- a/resources/com/coreos/profiles/embargoed-alpha.json
+++ b/resources/com/coreos/profiles/embargoed-alpha.json
@@ -7,4 +7,6 @@
     "GROUP": "alpha",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://alpha.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/alpha",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/embargoed-beta.json
+++ b/resources/com/coreos/profiles/embargoed-beta.json
@@ -7,4 +7,6 @@
     "GROUP": "beta",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://beta.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/beta",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/embargoed-stable.json
+++ b/resources/com/coreos/profiles/embargoed-stable.json
@@ -7,4 +7,6 @@
     "GROUP": "stable",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://stable.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/stable",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/embargoed.json
+++ b/resources/com/coreos/profiles/embargoed.json
@@ -26,6 +26,9 @@
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/embargoed/developer",
     "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-5df31bf86df3.json",
 
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "gs://builds.release.core-os.net/embargoed/developer/torcx",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://builds.release.core-os.net/embargoed/developer/torcx",
+
     "MANIFEST_URL": "ssh://core@52.37.67.219/~/manifest.git",
 
     "PACKET_CREDS": "d67b5bde-d138-487a-9da3-0f5f5f157310",

--- a/resources/com/coreos/profiles/stable.json
+++ b/resources/com/coreos/profiles/stable.json
@@ -7,4 +7,6 @@
     "GROUP": "stable",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://stable.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/stable",
+    "TECTONIC_TORCX_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
+    "TORCX_PKG_DOWNLOAD_ROOT": "gs://coreos-tectonic-torcx",
 }


### PR DESCRIPTION
This adds the necessary variables for uploading and downloading torcx
packages at various points, as well as for setting the download root
users will be able to access packages at.

i've attempted to include correct configurations for nightlies and all
channels.

This change should have no effect until https://github.com/coreos/scripts/pull/737 is merged