### PR TITLE
Revert "os/board/vm-matrix: Switch plume pre-release to raw AMI image"

### DIFF
--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -95,7 +95,7 @@ used to verify signed files and Git tags'''),
 
 /* Define downstream testing/prerelease builds for specific formats.  */
 def downstreams = [
-    'ami': { if (params.BOARD == 'amd64-usr')
+    'ami_vmdk': { if (params.BOARD == 'amd64-usr')
         build job: '../prerelease/aws', wait: false, parameters: [
             string(name: 'AWS_REGION', value: params.AWS_REGION),
             credentials(name: 'AWS_RELEASE_CREDS', value: params.AWS_RELEASE_CREDS),


### PR DESCRIPTION
VMDKs appear to work again.

This reverts commit 0e0643120e7e75feaf6d493e346569f20b6faa4c.