### PR TITLE
os/kola/gce: delete GCE image when done with it

### DIFF
--- a/os/kola/gce.groovy
+++ b/os/kola/gce.groovy
@@ -58,6 +58,10 @@ bin/ore gcloud create-image \
 
 GCE_NAME="${NAME//[+.]/-}-${COREOS_VERSION//[+.]/-}"
 
+trap 'bin/ore gcloud delete-images \
+    --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    "${GCE_NAME}"' EXIT
+
 timeout --signal=SIGQUIT 60m bin/kola run \
     --basename="${NAME}" \
     --gce-image="${GCE_NAME}" \


### PR DESCRIPTION
The image is easy to recreate from the uploaded tarball if we later need it for manual testing.