### PR TITLE
os/kola/dev-container: Use the kernel config that was just built

### DIFF
--- a/os/kola/dev-container.groovy
+++ b/os/kola/dev-container.groovy
@@ -64,7 +64,8 @@ sudo systemd-nspawn \
     /bin/bash -eux << 'EOF'
 emerge-gitclone
 emerge -gKv coreos-sources
-gzip -cd /proc/config.gz > /usr/src/linux/.config
+PKGDIR=/tmp PORTAGE_TMPDIR=/tmp ROOT=/tmp emerge -gKOv coreos-modules
+cp -f /tmp/usr/boot/config /usr/src/linux/.config
 exec make -C /usr/src/linux -j"$(nproc)" modules_prepare V=1
 EOF
 '''  /* Editor quote safety: ' */


### PR DESCRIPTION
The original commands were taken from the documentation, which expects to build modules for the host kernel.  The host kernel will not always match the version being built and tested here, though, so this takes the config from the binary package that was just built.  That package has to be downloaded and extracted in tmpfs to avoid filling the disk image.