### PR TITLE
os/kola: send summary of failures to slack

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -68,6 +68,8 @@ timeout --signal=SIGQUIT 60m bin/kola run \
     --tapfile="${JOB_NAME##*/}.tap" \
     --torcx-manifest=torcx_manifest.json
 '''  /* Editor quote safety: ' */
+
+                message = sh returnStdout: true, script: '''jq '.tests[] | select(.result == "FAIL") | .name' -r < _kola_temp/aws-latest/reports/report.json | paste -sd "," -'''
             }
         }
     }
@@ -97,3 +99,7 @@ timeout --signal=SIGQUIT 60m bin/kola run \
 
 /* Propagate the job status after publishing TAP results.  */
 currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'
+
+if (currentBuild.result == 'FAILURE')
+    slackSend color: 'danger',
+              message: "```Kola: AWS-amd64-$AWS_AMI_TYPE Failure: <$BUILD_URL|Build> - <${BUILD_URL}artifacts/_kola_temp.tar.xz|_kola_temp>\n$message```"

--- a/os/kola/do.groovy
+++ b/os/kola/do.groovy
@@ -113,6 +113,8 @@ timeout --signal=SIGQUIT 60m bin/kola run \
     --tapfile="${JOB_NAME##*/}.tap" \
     --torcx-manifest=torcx_manifest.json
 '''  /* Editor quote safety: ' */
+
+                    message = sh returnStdout: true, script: '''jq '.tests[] | select(.result == "FAIL") | .name' -r < _kola_temp/do-latest/reports/report.json | paste -sd "," -'''
                 }
             }
         }
@@ -143,3 +145,7 @@ timeout --signal=SIGQUIT 60m bin/kola run \
 
 /* Propagate the job status after publishing TAP results.  */
 currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'
+
+if (currentBuild.result == 'FAILURE')
+    slackSend color: 'danger',
+              message: "```Kola: DO-amd64 Failure: <$BUILD_URL|Build> - <${BUILD_URL}artifacts/_kola_temp.tar.xz|_kola_temp>\n$message```"

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -117,6 +117,8 @@ if [[ "${COREOS_BUILD_ID}" == *-master-* ]]; then
                   "${DOWNLOAD_ROOT}/boards/${BOARD}/current-master/version.txt"
 fi
 '''  /* Editor quote safety: ' */
+
+                message = sh returnStdout: true, script: '''jq '.tests[] | select(.result == "FAIL") | .name' -r < _kola_temp/qemu-latest/reports/report.json | paste -sd "," -'''
                 }
             }
         }
@@ -147,3 +149,7 @@ fi
 
 /* Propagate the job status after publishing TAP results.  */
 currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'
+
+if (currentBuild.result == 'FAILURE')
+    slackSend color: 'danger',
+              message: "```Kola: QEMU-amd64 Failure: <$BUILD_URL|Build> - <${BUILD_URL}artifacts/_kola_temp.tar.xz|_kola_temp>\n$message```"

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -112,6 +112,8 @@ enter sudo timeout --signal=SIGQUIT 60m kola run \
 
 sudo rm -rf tmp
 '''  /* Editor quote safety: ' */
+
+                message = sh returnStdout: true, script: '''jq '.tests[] | select(.result == "FAIL") | .name' -r < _kola_temp/qemu-latest/reports/report.json | paste -sd "," -'''
                 }
             }
         }
@@ -142,3 +144,7 @@ sudo rm -rf tmp
 
 /* Propagate the job status after publishing TAP results.  */
 currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'
+
+if (currentBuild.result == 'FAILURE')
+    slackSend color: 'danger',
+              message: "```Kola: QEMU_UEFI-$BOARD Failure: <$BUILD_URL|Build> - <${BUILD_URL}artifacts/_kola_temp.tar.xz|_kola_temp>\n$message```"


### PR DESCRIPTION
If any tests fail in a kola run posts a slack message with a list of
failed tests. Parses the list of failed test from the json output via
jq.