### PR TITLE
os/tectonic-nightly: fix slack message

### DIFF
--- a/os/tectonic-nightly.groovy
+++ b/os/tectonic-nightly.groovy
@@ -140,9 +140,8 @@ node('amd64 && docker') {
 }
 
 if (rc != 0)
-    slackSend color: 'bad',
-              message: '''tectonic-nightly failed!\n$BUILD_URL''',
+    slackSend color: 'danger',
+              message: "tectonic-nightly failed!\n$BUILD_URL",
               channel: '@slowrie'
 
-/* Propagate the job status after publishing TAP results.  */
 currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'


### PR DESCRIPTION
Currently it's using the wrong color & the message is in single quotes
causing the `$BUILD_URL` variable to not expand.