### PR TITLE
os/kola/aws: switch HVM instance type to m4.large

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -53,7 +53,7 @@ rm -rf *.tap _kola_temp*
 
 NAME="jenkins-${JOB_NAME##*/}-${BUILD_NUMBER}"
 
-instance_type="t2.small"
+instance_type="m4.large"
 if [[ "${AWS_AMI_TYPE}" == "PV" ]]; then
     instance_type="m3.medium"
 fi


### PR DESCRIPTION
Only the first 100 `t2` instances per region per account per day receive launch CPU credits. Now that AWS has per-second instance billing and we have automatic instance GC, it's safe to switch to a type without this limitation.