### PR TITLE
os/kola/oci: fix file permissions

### DIFF
--- a/os/kola/oci.groovy
+++ b/os/kola/oci.groovy
@@ -118,6 +118,7 @@ mkdir --mode=0700 .oci
 mv ${OCI_TEST_CONFIG} .oci/config
 mv ${OCI_TEST_KEY} .oci/oci_api_key.pem
 touch .oci/config.mantle
+chmod 0600 .oci/*
 
 trap 'rm -rf .oci' EXIT;
 compartment=$(awk -F "=" '/compartment/ {print $2}' .oci/config)


### PR DESCRIPTION
Currently the `oci` command-line tool spits out WARNING messages telling
the user to run a setup command to repair the file permissions. This
ends up amounting to changing the file mode of the config & RSA private
key to 0600. This PR pre-emptively changes the file mode as soon as they
are moved from the dynamic location created via credentials.