### PR TITLE
os/*: drop experimental flag from cork

### DIFF
--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -161,7 +161,7 @@ bin/cork update \
 sudo rm -rf gce.properties src tmp
 
 enter() {
-        bin/cork enter --experimental -- "$@"
+        bin/cork enter --bind-gpg-agent=false -- "$@"
 }
 
 script() {

--- a/os/docs-sync.groovy
+++ b/os/docs-sync.groovy
@@ -91,7 +91,7 @@ git -C coreos-pages checkout -B ${branch}
         stage('Build') {
             if (base == '')
                 sh '''#!/bin/bash -ex
-bin/cork enter --experimental -- \
+bin/cork enter --bind-gpg-agent=false -- \
     cargo build --package=sync --release --verbose \
         --manifest-path=/mnt/host/source/pages/sync/Cargo.toml
 ln -fns target/release/sync  pages/sync/sync
@@ -127,7 +127,7 @@ git -C coreos-pages commit -am "os: prune old ${channel} releases" || :
                 sh """#!/bin/bash -ex
 cp "\${GOOGLE_APPLICATION_CREDENTIALS}" account.json && chmod 0600 account.json
 trap 'shred -u account.json' EXIT
-bin/cork enter --experimental -- /bin/bash -ex << 'EOF'
+bin/cork enter --bind-gpg-agent=false -- /bin/bash -ex << 'EOF'
 gcloud auth activate-service-account --key-file=/mnt/host/source/account.json
 cd /mnt/host/source/coreos-pages
 ../pages/scripts/sync-release ${channel} ${version}

--- a/os/kola/do.groovy
+++ b/os/kola/do.groovy
@@ -91,7 +91,7 @@ source .repo/manifests/version.txt
 
 set -o pipefail
 ln -f "${GOOGLE_APPLICATION_CREDENTIALS}" credentials.json
-bin/cork enter --experimental -- gsutil signurl -d 30m \
+bin/cork enter --bind-gpg-agent=false -- gsutil signurl -d 30m \
     /mnt/host/source/credentials.json \
     "${DOWNLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}/coreos_production_digitalocean_image.bin.bz2" |
 sed -n 's,^.*https://,https://,p' > url.txt

--- a/os/kola/oci.groovy
+++ b/os/kola/oci.groovy
@@ -101,7 +101,7 @@ bin/cork update \
 [ -s verify.asc ] && verify_key=--verify-key=verify.asc || verify_key=
 
 enter() {
-    bin/cork enter --experimental -- "$@"
+    bin/cork enter --bind-gpg-agent=false -- "$@"
 }
 
 mkdir -p src
@@ -136,7 +136,7 @@ sudo cp -t chroot/usr/bin bin/[b-z]*
 # location for the configuration files (the .oci/config must point
 # to the .oci/oci_api_key.pem files location and cannot be configured
 # via parameters).
-bin/cork enter --experimental -- region=$region bucket=$bucket object=$object compartment=$compartment NAME=$NAME OCI_SHAPE=$OCI_SHAPE sh -ex << 'EOF'
+bin/cork enter --bind-gpg-agent=false -- region=$region bucket=$bucket object=$object compartment=$compartment NAME=$NAME OCI_SHAPE=$OCI_SHAPE sh -ex << 'EOF'
 pyvenv ocienv && ocienv/bin/pip install oci-cli --upgrade;
 ln -fns /mnt/host/source/.oci ~/.oci
 export LC_ALL=C.UTF-8;

--- a/os/kola/packet.groovy
+++ b/os/kola/packet.groovy
@@ -107,7 +107,7 @@ timeout=3h
 
 set -o pipefail
 ln -f "${GOOGLE_APPLICATION_CREDENTIALS}" credentials.json
-bin/cork enter --experimental -- gsutil signurl -d "${timeout}" \
+bin/cork enter --bind-gpg-agent=false -- gsutil signurl -d "${timeout}" \
     /mnt/host/source/credentials.json \
     "${DOWNLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}/coreos_production_packet_image.bin.bz2" |
 sed -n 's,^.*https://,https://,p' > url.txt

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -65,7 +65,7 @@ node('amd64 && kvm && sudo') {
 sudo rm -rf *.tap src/scripts/_kola_temp tmp _kola_temp*
 
 enter() {
-  bin/cork enter --experimental -- "$@"
+  bin/cork enter --bind-gpg-agent=false -- "$@"
 }
 
 # Set up GPG for verifying tags.

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -68,7 +68,7 @@ node('amd64 && kvm && sudo') {
 sudo rm -rf *.tap src/scripts/_kola_temp tmp _kola_temp*
 
 enter() {
-  bin/cork enter --experimental -- "$@"
+  bin/cork enter --bind-gpg-agent=false -- "$@"
 }
 
 # Set up GPG for verifying tags.

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -194,7 +194,7 @@ bin/cork update \
     --new-version "${COREOS_VERSION}" \
     --sdk-version "${COREOS_SDK_VERSION}"
 
-bin/cork enter --experimental -- sh -exc \
+bin/cork enter --bind-gpg-agent=false -- sh -exc \
     "cd /mnt/host/source && repo manifest -r > 'manifest/${COREOS_BUILD_ID}.xml'"
 
 ln -fns "${COREOS_BUILD_ID}.xml" manifest/default.xml
@@ -236,7 +236,7 @@ finish "${COREOS_BUILD_ID}"
             ]) {
                 withEnv(["DEVEL_ROOT=${profile.GS_DEVEL_ROOT}"]) {
                     sh '''#!/bin/bash -ex
-bin/cork enter --experimental -- \
+bin/cork enter --bind-gpg-agent=false -- \
     gsutil cat "${DEVEL_ROOT}/boards/amd64-usr/current-master/version.txt" |
 tee /dev/stderr |
 grep -m1 ^COREOS_VERSION= > current.txt

--- a/os/mirror/nightly.groovy
+++ b/os/mirror/nightly.groovy
@@ -32,7 +32,7 @@ node('coreos && amd64 && sudo') {
         ]) {
             sh '''#!/bin/bash -ex
 bin/cork update --create --verbose --force-sync
-bin/cork enter --experimental -- \
+bin/cork enter --bind-gpg-agent=false -- \
     /mnt/host/source/src/scripts/update_distfiles --download --upload coreos portage-stable
 '''
         }

--- a/os/release_oci.groovy
+++ b/os/release_oci.groovy
@@ -71,7 +71,7 @@ bin/cork update \
 [ -s verify.asc ] && verify_key=--verify-key=verify.asc || verify_key=
 
 enter() {
-    bin/cork enter --experimental -- "$@"
+    bin/cork enter --bind-gpg-agent=false -- "$@"
 }
 
 rm -rf ~/.oci
@@ -98,7 +98,7 @@ object="Container-Linux-${CHANNEL}-${VERSION}.qcow"
 rm -rf src/.oci
 cp -r ~/.oci src/
 trap 'rm -rf src/.oci ~/.oci/' EXIT;
-bin/cork enter --experimental -- region=$region bucket=$bucket object=$object sh -ex << 'EOF'
+bin/cork enter --bind-gpg-agent=false -- region=$region bucket=$bucket object=$object sh -ex << 'EOF'
 rm -rf ocienv/;
 pyvenv ocienv && ocienv/bin/pip install oci-cli;
 cp -r /mnt/host/source/src/.oci ~/;


### PR DESCRIPTION
As of coreos/mantle#814 cork now defaults to experimental and the flag
itself is deprecated. Drops the flag to remove warnings.