### PR TITLE
os/kola/oci: exit if image not available after 1 hour

### DIFF
--- a/os/kola/oci.groovy
+++ b/os/kola/oci.groovy
@@ -172,6 +172,11 @@ ocienv/bin/oci os object delete \
      --name "${object}" \
      --force
 
+if [ "$state" != "AVAILABLE" ]; then
+    # The image isn't available after 1 hour, exit
+    exit 1
+fi
+
 timeout --signal=SIGQUIT 300m kola run \
     --parallel=1 \
     --basename="${NAME}" \


### PR DESCRIPTION
Currently we don't assert that the image is available after the 1 hour
loop before running kola.