### PR TITLE
Add --force-sync to cork update

### DIFF
--- a/os/board/image-matrix.groovy
+++ b/os/board/image-matrix.groovy
@@ -164,6 +164,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/board/packages-matrix.groovy
+++ b/os/board/packages-matrix.groovy
@@ -153,6 +153,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}" \

--- a/os/board/sign-image.groovy
+++ b/os/board/sign-image.groovy
@@ -152,6 +152,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/board/vm-matrix.groovy
+++ b/os/board/vm-matrix.groovy
@@ -260,6 +260,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/kola/do.groovy
+++ b/os/kola/do.groovy
@@ -83,6 +83,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/kola/oci.groovy
+++ b/os/kola/oci.groovy
@@ -93,6 +93,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/kola/packet.groovy
+++ b/os/kola/packet.groovy
@@ -97,6 +97,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -77,6 +77,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -80,6 +80,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -187,7 +187,7 @@ fi
 
 # Initialize an SDK without verifying a manifest tag, since this uses a branch.
 bin/cork update \
-    --create --downgrade-replace --verbose \
+    --create --downgrade-replace --verbose --force-sync \
     --manifest-branch "${GIT_COMMIT}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${GIT_URL}" \

--- a/os/mirror/nightly.groovy
+++ b/os/mirror/nightly.groovy
@@ -31,7 +31,7 @@ node('coreos && amd64 && sudo') {
             file(credentialsId: params.GCS_CREDS, variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
         ]) {
             sh '''#!/bin/bash -ex
-bin/cork update --create --verbose
+bin/cork update --create --verbose --force-sync
 bin/cork enter --experimental -- \
     /mnt/host/source/src/scripts/update_distfiles --download --upload coreos portage-stable
 '''

--- a/os/release_oci.groovy
+++ b/os/release_oci.groovy
@@ -63,6 +63,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/v${VERSION}" \
     --manifest-name "release.xml" \
     --manifest-url "https://github.com/coreos/manifest-builds.git"

--- a/os/sdk.groovy
+++ b/os/sdk.groovy
@@ -88,6 +88,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"

--- a/os/toolchains.groovy
+++ b/os/toolchains.groovy
@@ -146,6 +146,7 @@ gpg --import verify.asc
 
 bin/cork update \
     --create --downgrade-replace --verify --verify-signature --verbose \
+    --force-sync \
     --manifest-branch "refs/tags/${MANIFEST_TAG}" \
     --manifest-name "${MANIFEST_NAME}" \
     --manifest-url "${MANIFEST_URL}"


### PR DESCRIPTION
Our jenkins jobs will re-use an existing set of git repoitories on the
node, and depending on what job ran previously, 'repo sync' may need
the --force-sync flag to get the repoitories into the correct state.

Fixes errors like these:

    error: Cannot fetch coreos/coreos-overlay GitError: --force-sync not enabled; cannot overwrite a local work tree.
