### PR TITLE
os/kola/qemu_uefi: bump timeout to 120m

### DIFF
--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -102,7 +102,7 @@ sudo cp -t chroot/usr/lib/kola/arm64 bin/arm64/*
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
 sudo cp -t chroot/usr/bin bin/[b-z]*
 
-enter sudo timeout --signal=SIGQUIT 60m kola run \
+enter sudo timeout --signal=SIGQUIT 120m kola run \
     --board="${BOARD}" \
     --parallel=2 \
     --platform=qemu \


### PR DESCRIPTION
The arm tests for qemu_uefi always time out. Bump the timeout so they
(hopefully) do not.