### PR TITLE
Use a different jenkins for alpha/beta/stable channels, bump it to the new subkey

### DIFF
--- a/resources/com/coreos/profiles/alpha.json
+++ b/resources/com/coreos/profiles/alpha.json
@@ -10,6 +10,8 @@
     "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://alpha.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/alpha",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/alpha.json
+++ b/resources/com/coreos/profiles/alpha.json
@@ -4,7 +4,10 @@
 {
     "PARENT": "developer",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "alpha",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://alpha.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/alpha",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",

--- a/resources/com/coreos/profiles/beta.json
+++ b/resources/com/coreos/profiles/beta.json
@@ -10,6 +10,8 @@
     "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://beta.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/beta",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/beta.json
+++ b/resources/com/coreos/profiles/beta.json
@@ -4,7 +4,10 @@
 {
     "PARENT": "developer",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "beta",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://beta.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/beta",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",

--- a/resources/com/coreos/profiles/embargoed-alpha.json
+++ b/resources/com/coreos/profiles/embargoed-alpha.json
@@ -4,9 +4,14 @@
 {
     "PARENT": "embargoed",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "alpha",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://alpha.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/alpha",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/embargoed-beta.json
+++ b/resources/com/coreos/profiles/embargoed-beta.json
@@ -4,9 +4,14 @@
 {
     "PARENT": "embargoed",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "beta",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://beta.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/beta",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/embargoed-stable.json
+++ b/resources/com/coreos/profiles/embargoed-stable.json
@@ -4,9 +4,14 @@
 {
     "PARENT": "embargoed",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "stable",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://stable.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/stable",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }

--- a/resources/com/coreos/profiles/stable.json
+++ b/resources/com/coreos/profiles/stable.json
@@ -4,7 +4,10 @@
 {
     "PARENT": "developer",
     "AWS_RELEASE_CREDS": "d919f31a-22a4-4272-a5d2-67b6d9555209",
+    "BUILD_ID_PREFIX": "jenkins4-",
     "GROUP": "stable",
+    "GS_DEVEL_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
+    "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://stable.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/stable",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",

--- a/resources/com/coreos/profiles/stable.json
+++ b/resources/com/coreos/profiles/stable.json
@@ -10,6 +10,8 @@
     "GS_RELEASE_CREDS": "jenkins-coreos-systems-write-64233b5eccbf.json",
     "GS_RELEASE_DOWNLOAD_ROOT": "https://stable.release.core-os.net",
     "GS_RELEASE_ROOT": "gs://builds.release.core-os.net/stable",
+    "SIGNING_CREDS": "7fdc5e5b-560c-4cf6-a86e-531d2401d41a",
+    "SIGNING_USER": "0x0638EB2F!",
     "TORCX_PUBLIC_DOWNLOAD_ROOT": "https://tectonic-torcx.release.core-os.net",
     "TORCX_ROOT": "gs://coreos-tectonic-torcx",
 }


### PR DESCRIPTION
I've arbitrarily picked the build-id of 'jenkins4' for it. Other changes here are rote credential id changes.

Only a few are necessary since the majority of the credential ids have been kept the same.