### PR TITLE
os/kola/dev-container: Use the master branch's kernel correctly

### DIFF
--- a/os/kola/dev-container.groovy
+++ b/os/kola/dev-container.groovy
@@ -63,8 +63,14 @@ sudo systemd-nspawn \
     --image=coreos_developer_container.bin \
     /bin/bash -eux << 'EOF'
 emerge-gitclone
-emerge -gKv coreos-sources
-PKGDIR=/tmp PORTAGE_TMPDIR=/tmp ROOT=/tmp emerge -gKOv coreos-modules
+. /usr/share/coreos/release
+if [[ $COREOS_RELEASE_VERSION =~ master ]]
+then
+        git -C /var/lib/portage/portage-stable checkout master
+        git -C /var/lib/portage/coreos-overlay checkout master
+fi
+emerge -gv coreos-sources
+PKGDIR=/tmp PORTAGE_TMPDIR=/tmp ROOT=/tmp emerge -gOv coreos-modules
 cp -f /tmp/usr/boot/config /usr/src/linux/.config
 exec make -C /usr/src/linux -j"$(nproc)" modules_prepare V=1
 EOF


### PR DESCRIPTION
The emerge-gitclone command expects to work with release numbers to determine where to find the kernel.  When building off master, the major version number is the same as the latest alpha.

To work around this, test if the version string contains a "master" substring, and check out the master branches' ebuilds if so.