### PR TITLE
os/kola: Bump most timeouts to account for more tests

### DIFF
--- a/os/kola/aws.groovy
+++ b/os/kola/aws.groovy
@@ -58,7 +58,7 @@ if [[ "${AWS_AMI_TYPE}" == "PV" ]]; then
     instance_type="m3.medium"
 fi
 
-timeout --signal=SIGQUIT 120m bin/kola run \
+timeout --signal=SIGQUIT 3h bin/kola run \
     --parallel=4 \
     --basename="${NAME}" \
     --aws-ami="${AWS_AMI_ID}" \

--- a/os/kola/do.groovy
+++ b/os/kola/do.groovy
@@ -105,7 +105,7 @@ trap 'bin/ore do delete-image \
     --name="jenkins-${BUILD_NUMBER}" \
     --config-file="${DIGITALOCEAN_CREDS}"' EXIT
 
-timeout --signal=SIGQUIT 60m bin/kola run \
+timeout --signal=SIGQUIT 2h bin/kola run \
     --basename="${NAME}" \
     --do-config-file="${DIGITALOCEAN_CREDS}" \
     --do-image="${NAME}" \

--- a/os/kola/gce.groovy
+++ b/os/kola/gce.groovy
@@ -62,7 +62,7 @@ trap 'bin/ore gcloud delete-images \
     --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
     "${GCE_NAME}"' EXIT
 
-timeout --signal=SIGQUIT 60m bin/kola run \
+timeout --signal=SIGQUIT 3h bin/kola run \
     --basename="${NAME}" \
     --gce-image="${GCE_NAME}" \
     --gce-json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \

--- a/os/kola/packet.groovy
+++ b/os/kola/packet.groovy
@@ -103,7 +103,7 @@ bin/cork update \
     --manifest-url "${MANIFEST_URL}"
 source .repo/manifests/version.txt
 
-timeout=3h
+timeout=4h
 
 set -o pipefail
 ln -f "${GOOGLE_APPLICATION_CREDENTIALS}" credentials.json

--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -102,7 +102,7 @@ sudo cp -t chroot/usr/lib/kola/arm64 bin/arm64/*
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
 sudo cp -t chroot/usr/bin bin/[b-z]*
 
-enter sudo timeout --signal=SIGQUIT 60m kola run \
+enter sudo timeout --signal=SIGQUIT 2h kola run \
     --board="${BOARD}" \
     --parallel=2 \
     --platform=qemu \

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -102,7 +102,7 @@ sudo cp -t chroot/usr/lib/kola/arm64 bin/arm64/*
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
 sudo cp -t chroot/usr/bin bin/[b-z]*
 
-enter sudo timeout --signal=SIGQUIT 120m kola run \
+enter sudo timeout --signal=SIGQUIT 2h kola run \
     --board="${BOARD}" \
     --parallel=2 \
     --platform=qemu \


### PR DESCRIPTION
GCE is always timing out, and the others are usually within 15 minutes of the limit.