### PR TITLE
os/kola/dev-container: Uniquely name each nspawn machine

### DIFF
--- a/os/kola/dev-container.groovy
+++ b/os/kola/dev-container.groovy
@@ -67,6 +67,7 @@ sudo systemd-nspawn \
     --bind-ro=/lib/modules \
     --bind-ro="$PWD/coreos_production_image_kernel_config.txt:/boot/config" \
     --image=coreos_developer_container.bin \
+    --machine=coreos-developer-container-$(uuidgen) \
     --tmpfs=/var/tmp \
     /bin/bash -eux << 'EOF'
 emerge-gitclone


### PR DESCRIPTION
Allow multiple dev-container jobs to run simultaneously on a worker.  Fixes error:

    Failed to register machine: Machine 'coreos_developer_container.bin' already exists