### PR TITLE
os/kola/dev-container: Mount tmpfs over /usr/src

### DIFF
--- a/os/kola/dev-container.groovy
+++ b/os/kola/dev-container.groovy
@@ -68,6 +68,7 @@ sudo systemd-nspawn \
     --bind-ro="$PWD/coreos_production_image_kernel_config.txt:/boot/config" \
     --image=coreos_developer_container.bin \
     --machine=coreos-developer-container-$(uuidgen) \
+    --tmpfs=/usr/src \
     --tmpfs=/var/tmp \
     /bin/bash -eux << 'EOF'
 emerge-gitclone


### PR DESCRIPTION
Some kernel versions are running out of disk space on the container image during "make modules_prepare", so work around it by running on tmpfs.