### PR TITLE
kola/qemu: drop mkimage

### DIFF
--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -94,9 +94,6 @@ bin/cork download-image \
     --verify=true $verify_key
 enter lbunzip2 -k -f /mnt/host/source/tmp/coreos_production_image.bin.bz2
 
-# edit the kernel command-line to save console output
-sudo bin/kola mkimage tmp/coreos_production_image.bin tmp/coreos_modified.bin
-
 # copy all of the latest mantle binaries into the chroot
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
 sudo cp -t chroot/usr/bin bin/[b-z]*
@@ -106,7 +103,7 @@ enter sudo timeout --signal=SIGQUIT 2h kola run \
     --parallel=2 \
     --platform=qemu \
     --qemu-bios=bios-256k.bin \
-    --qemu-image=/mnt/host/source/tmp/coreos_modified.bin \
+    --qemu-image=/mnt/host/source/tmp/coreos_production_image.bin \
     --tapfile="/mnt/host/source/${JOB_NAME##*/}.tap" \
     --torcx-manifest=/mnt/host/source/torcx_manifest.json
 

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -104,6 +104,7 @@ enter sudo timeout --signal=SIGQUIT 2h kola run \
     --platform=qemu \
     --qemu-bios=/mnt/host/source/tmp/coreos_production_qemu_uefi_efi_code.fd \
     --qemu-image=/mnt/host/source/tmp/coreos_production_image.bin \
+    --qemu-skip-mangle \
     --tapfile="/mnt/host/source/${JOB_NAME##*/}.tap" \
     --torcx-manifest=/mnt/host/source/torcx_manifest.json
 


### PR DESCRIPTION
kola now modifies qemu images automatically; `kola mkimage` was removed.  `qemu_uefi` intentionally tests a vanilla image, so pass `--qemu-skip-mangle` to continue doing so.

Part of https://github.com/coreos/mantle/pull/940.