### PR TITLE
resources: Update the build ID prefix

### DIFF
--- a/resources/com/coreos/profiles/developer.json
+++ b/resources/com/coreos/profiles/developer.json
@@ -22,7 +22,7 @@
      * manifest job, when reusing build numbers would cause conflicting
      * branch names in the manifest-builds repository.
      */
-    "BUILD_ID_PREFIX": "jenkins2-",
+    "BUILD_ID_PREFIX": "jenkins3-",
 
     /*
      * The manifest-builds repository holds the manifest files for each

--- a/resources/com/coreos/profiles/embargoed.json
+++ b/resources/com/coreos/profiles/embargoed.json
@@ -8,7 +8,7 @@
 
     "AZURE_CREDS": "7ab88376-e794-4128-b644-41c83c89e76d",
 
-    "BUILD_ID_PREFIX": "jenkins2-",
+    "BUILD_ID_PREFIX": "jenkins3-",
 
     "BUILDS_CLONE_URL": "ssh://core@35.197.82.132/coreos/manifest-builds.git",
     "BUILDS_CLONE_CREDS": "3d4319c2-bca1-47c8-a483-2f355c249e30",


### PR DESCRIPTION
We're switching to a new Jenkins instance, so bump this value to avoid conflicting tag names.