### PR TITLE
plugins/cldsv: Bump the Gradle JPI plugin version

### DIFF
--- a/plugins/cldsv/build.gradle
+++ b/plugins/cldsv/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jenkins-ci.jpi' version '0.22.0'  // Oldest version tested
+    id 'org.jenkins-ci.jpi' version '0.28.1'
 }
 
 description = 'Render every triggered job run for a Container Linux build'


### PR DESCRIPTION
Current Gradle failed to build with the previous version last time I compiled this plugin, so update it here in case anyone else tries to build this.