### PR TITLE
os/manifest: Drop the + in build metadata

### DIFF
--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -109,7 +109,7 @@ enter sudo timeout --signal=SIGQUIT 2h kola run \
 
 sudo rm -rf tmp
 
-if [[ "${COREOS_BUILD_ID}" == *-master-* ]]; then
+if [[ "${COREOS_BUILD_ID}" == *-master-[0-9]* ]]; then
   enter gsutil cp "${DOWNLOAD_ROOT}/boards/${BOARD}/${COREOS_VERSION}/version.txt" \
                   "${DOWNLOAD_ROOT}/boards/${BOARD}/current-master/version.txt"
 fi

--- a/os/manifest.groovy
+++ b/os/manifest.groovy
@@ -182,7 +182,7 @@ if [[ -n "${LOCAL_MANIFEST}" ]]
 then
         mkdir -p .repo/local_manifests
         echo "${LOCAL_MANIFEST}" > .repo/local_manifests/local.xml
-        COREOS_BUILD_ID="${BUILD_ID_PREFIX}${MANIFEST_BRANCH}+local-${BUILD_NUMBER}"
+        COREOS_BUILD_ID="${BUILD_ID_PREFIX}${MANIFEST_BRANCH}-local-${BUILD_NUMBER}"
 fi
 
 # Initialize an SDK without verifying a manifest tag, since this uses a branch.


### PR DESCRIPTION
Fix reusing workspaces while testing pull requests after coreos/go-semver@776a93a64459f9f09ab33d9ef256dd089d70a31c.