### PR TITLE
os/update-linux: don't test beta branch for now

### DIFF
--- a/os/update-linux.groovy
+++ b/os/update-linux.groovy
@@ -230,7 +230,7 @@ revision="refs/pull/${channelPR['master']}/head"/>
 </manifest>
 """),
     ]
-    for (channel in ['alpha', 'beta'])
+    for (channel in ['alpha'])
         build job: 'manifest', propagate: false, wait: true, parameters: [
             string(name: 'MANIFEST_REF', value: "build-${channelRelease[channel].split(/[.]/)[0]}"),
             string(name: 'RELEASE_BASE', value: channelRelease[channel]),


### PR DESCRIPTION
To avoid having to clear workspaces for the binutils upgrade, skip testing beta kernel bumps for now.  There's little enough churn now that this should be safe.

Revert after 2247 reaches beta.