### PR TITLE
os/kola/qemu: update glob match pattern in qemu scripts

### DIFF
--- a/os/kola/qemu.groovy
+++ b/os/kola/qemu.groovy
@@ -95,7 +95,8 @@ enter lbunzip2 -k -f /mnt/host/source/tmp/coreos_production_image.bin.bz2
 
 # copy all of the latest mantle binaries into the chroot
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
-sudo cp -t chroot/usr/bin bin/[b-z]*
+# skip copying architecture folders (amd64, arm64, s390x)
+sudo cp -t chroot/usr/bin bin/[b-rt-z]*
 
 enter sudo timeout --signal=SIGQUIT 2h kola run \
     --board="${BOARD}" \

--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -95,7 +95,8 @@ enter lbunzip2 -k -f /mnt/host/source/tmp/coreos_production_image.bin.bz2
 
 # copy all of the latest mantle binaries into the chroot
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*
-sudo cp -t chroot/usr/bin bin/[b-z]*
+# skip copying architecture folders (amd64, arm64, s390x)
+sudo cp -t chroot/usr/bin bin/[b-rt-z]*
 
 enter sudo timeout --signal=SIGQUIT 2h kola run \
     --board="${BOARD}" \


### PR DESCRIPTION
Updates the glob match pattern used to copy mantle binaries in the QEMU
scripts to skip the s390x directory as it's not used on Container Linux.