### PR TITLE
Revert "os/update-linux: don't test beta branch for now"

### DIFF
--- a/os/update-linux.groovy
+++ b/os/update-linux.groovy
@@ -230,7 +230,7 @@ revision="refs/pull/${channelPR['master']}/head"/>
 </manifest>
 """),
     ]
-    for (channel in ['alpha'])
+    for (channel in ['alpha', 'beta'])
         build job: 'manifest', propagate: false, wait: true, parameters: [
             string(name: 'MANIFEST_REF', value: "build-${channelRelease[channel].split(/[.]/)[0]}"),
             string(name: 'RELEASE_BASE', value: channelRelease[channel]),


### PR DESCRIPTION
2247 promoted to beta, so we can resume testing beta kernel bumps.

This reverts commit d3d0d9fc3de75da5c47537ed297ea5bbaa8c3c5e.