### PR TITLE
os/docs-sync: disallow BASE_VERSION empty for non-alpha X.0.Z builds

### DIFF
--- a/os/docs-sync.groovy
+++ b/os/docs-sync.groovy
@@ -38,6 +38,11 @@ def version = params.VERSION
 def branch = "build-${version.split(/\./)[0]}"
 def latest = [auto: channel == 'alpha'].withDefault{it == 'yes'}[params.LATEST]
 
+if ((channel != 'alpha' || version =~ '\\d\\.[1-9]\\d*\\.\\d+') && base == '') {
+    currentBuild.result = 'FAILURE'
+    return
+}
+
 def forkProject = "${username}/${docsProject.split('/')[-1]}"
 
 def docsUrl = "ssh://git@github.com/${docsProject}.git"


### PR DESCRIPTION
During the release of 2275.0.0 & 2247.3.0 the 2247.3.0 docs-sync build
was ran without specifying a BASE_VERSION which caused the index.html to
not be generated. Now enforce that BASE_VERSION is specified for any
builds on channels other than alpha or alpha builds that are not a X.0.Z
version.