### PR TITLE
init.groovy: switch to cl branch for master-builder mantle job

### DIFF
--- a/init.groovy
+++ b/init.groovy
@@ -160,7 +160,7 @@ createPipeline('master-builder',
                createFolder('mantle'),
                'Build mantle from master for the other jobs.',
                'https://github.com/coreos/mantle.git',
-               'master',
+               'cl',
                'Jenkinsfile',
                'master')
 


### PR DESCRIPTION
The mantle project has created a branch for CL specifically no longer
guaranteeing that the master branch will build successfully on CL.