### PR TITLE
os/kola/qemu_uefi: also inject GIT_* env vars

### DIFF
--- a/os/kola/qemu_uefi.groovy
+++ b/os/kola/qemu_uefi.groovy
@@ -56,6 +56,10 @@ node('amd64 && kvm && sudo') {
             ]) {
                 withEnv(['BOARD=amd64-usr',
                          "DOWNLOAD_ROOT=${params.DOWNLOAD_ROOT}",
+                         "GIT_AUTHOR_EMAIL=team-os@coreos.com",
+                         "GIT_AUTHOR_NAME=Jenkins OS",
+                         "GIT_COMMITTER_EMAIL=team-os@coreos.com",
+                         "GIT_COMMITTER_NAME=Jenkins OS",
                          "MANIFEST_NAME=${params.MANIFEST_NAME}",
                          "MANIFEST_TAG=${params.MANIFEST_TAG}",
                          "MANIFEST_URL=${params.MANIFEST_URL}"]) {


### PR DESCRIPTION
Missed this one in the previous commit.