### PR TITLE
docs-groovy: improve error mode when checking base upfront

### DIFF
--- a/os/docs-sync.groovy
+++ b/os/docs-sync.groovy
@@ -39,6 +39,7 @@ def branch = "build-${version.split(/\./)[0]}"
 def latest = [auto: channel == 'alpha'].withDefault{it == 'yes'}[params.LATEST]
 
 if ((channel != 'alpha' || version =~ '\\d\\.[1-9]\\d*\\.\\d+') && base == '') {
+    println 'Missing BASE_VERSION parameter for non-alpha or branched alpha build!'
     currentBuild.result = 'FAILURE'
     return
 }


### PR DESCRIPTION
Should make it easier to find out what's going on if one messes up the
parameters.

(Would be cool if Jenkins/Groovy had the equivalent of `set -x` too).